### PR TITLE
Track `jstring`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - 3.6
+  - 3.7
 
 install:
   - pip install -r requirements.txt

--- a/jnitrace/src/main.ts
+++ b/jnitrace/src/main.ts
@@ -316,5 +316,3 @@ JNIInterceptor.attach("NewDirectByteBuffer", jniEnvCallback);
 JNIInterceptor.attach("GetDirectBufferAddress", jniEnvCallback);
 JNIInterceptor.attach("GetDirectBufferCapacity", jniEnvCallback);
 JNIInterceptor.attach("GetObjectRefType", jniEnvCallback);
-
-

--- a/jnitrace/src/transport/data_transport.ts
+++ b/jnitrace/src/transport/data_transport.ts
@@ -147,6 +147,8 @@ class DataTransport {
 
     private readonly jmethodIDs: Map<string, string>;
 
+    private readonly jstrings: Map<string, string>;
+
     private include: string[];
 
     private exclude: string[];
@@ -157,6 +159,7 @@ class DataTransport {
         this.jobjects = new Map<string, string>();
         this.jfieldIDs = new Map<string, string>();
         this.jmethodIDs = new Map<string, string>();
+        this.jstrings = new Map<string, string>();
         this.include = [];
         this.exclude = [];
     }
@@ -336,6 +339,13 @@ class DataTransport {
         }
     }
 
+    private updateStringIDs (data: MethodData): void {
+        const UTF8_INDEX = 1;
+        this.jstrings.set(data.ret.toString(),
+            data.getArgAsPtr(UTF8_INDEX).readUtf8String()!
+        );
+    }
+
     private updateState (data: MethodData): void {
         const name = data.method.name;
 
@@ -357,6 +367,8 @@ class DataTransport {
             this.updateObjectIDsFromClass(data);
         } else if (name.startsWith("Call")) {
             this.updateObjectIDsFromCall(data);
+        } else if (name === "NewStringUTF") {
+            this.updateStringIDs(data);
         }
     }
 
@@ -399,6 +411,10 @@ class DataTransport {
         } else if (type === "jfieldID") {
             if (this.jfieldIDs.has(key)) {
                 item.setMetadata(this.jfieldIDs.get(key));
+            }
+        } else if (type === "jstring") {
+            if (this.jstrings.has(key)) {
+                item.setMetadata(this.jstrings.get(key));
             }
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
-    "compilerOptions": {
-      "target": "esnext",
-      "lib": ["esnext"],
-      "allowJs": true,
-      "noEmit": true,
-      "strict": true,
-      "esModuleInterop": true,
-      "resolveJsonModule": true,
-      "moduleResolution": "node"
-    }
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["esnext"],
+    "allowJs": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "node"
   }
-  
+}


### PR DESCRIPTION
Solves this "problem":

```
a = jni -> NewStringUTF("test")
b = jni -> NewStringUTF("alice")
c = jni -> NewStringUTF("bob")

jni -> CallObjectMethodV(b)  // <-- what string was b ?
```

After this patch the last `ro.board.platform` is now printed:

```
    257 ms [+] JNIEnv->NewStringUTF
    257 ms |- JNIEnv*          : 0xee821230
    257 ms |- char*            : 0xffacaff8
    257 ms |:     ro.board.platform
    257 ms |= jstring          : 0x1d    { ro.board.platform }

   [...]

    572 ms [+] JNIEnv->CallStaticObjectMethod
    572 ms |- JNIEnv*          : 0xee821230
    572 ms |- jclass           : 0x21    { android/os/SystemProperties }
    572 ms |- jmethodID        : 0x70f58db0    { get(Ljava/lang/String;)Ljava/lang/String; }
    572 ms |: jstring          : 0x1d    { ro.board.platform }
    572 ms |= jobject          : 0x100025    { java/lang/String }
```


Unrelated change to `tsconfig.json`:
 * Change indentation
 *  Add `skipLibCheck: true` -- this make the project compile with yarn